### PR TITLE
[centosBugfix] k8s script bug fix

### DIFF
--- a/scripts/centos/k8s.sh
+++ b/scripts/centos/k8s.sh
@@ -10,6 +10,7 @@ sudo sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
 modprobe overlay
 modprobe br_netfilter
 echo '1' > /proc/sys/net/bridge/bridge-nf-call-iptables
+echo '1' > /proc/sys/net/ipv4/ip_forward
 
 swapoff -a
 


### PR DESCRIPTION
  - 상황: k8s init시 "[ERROR FileContent--proc-sys-net-ipv4-ip_forward]: /proc/sys/net/ipv4/ip_forward contents are not set to 1" error 발생
  - 해결: k8s script에 "echo '1' > /proc/sys/net/ipv4/ip_forward" 추가